### PR TITLE
A46 locked sets and cloning sets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-group :test do
+group :test, :development do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'database_cleaner'

--- a/app/controllers/api/v1/sets_controller.rb
+++ b/app/controllers/api/v1/sets_controller.rb
@@ -35,8 +35,8 @@ module Api
         unless copy.save
           return render json: { errors: [{ status: '422', title: 'Unprocessable entity', detail: 'The clone could not be created'}]}, status: :unprocessable_entity
         end
-        # Ideally, render the complete JSONAPI version of the copy, with links, but I can't find any way to do that
-        render json: copy, status: :created
+        # TODO: Ideally, render the complete JSONAPI version of the copy, with links, but I can't find any way to do that
+        render json: { data: copy }, status: :created
       end
 
     private

--- a/app/controllers/api/v1/sets_controller.rb
+++ b/app/controllers/api/v1/sets_controller.rb
@@ -35,8 +35,8 @@ module Api
         unless copy.save
           return render json: { errors: [{ status: '422', title: 'Unprocessable entity', detail: 'The clone could not be created'}]}, status: :unprocessable_entity
         end
-        # TODO: Ideally, render the complete JSONAPI version of the copy, with links, but I can't find any way to do that
-        render json: { data: copy }, status: :created
+        jsondata = JSONAPI::ResourceSerializer.new(Api::V1::SetResource).serialize_to_hash(Api::V1::SetResource.new(copy, nil))
+        render json: jsondata, status: :created
       end
 
     private

--- a/app/controllers/api/v1/sets_controller.rb
+++ b/app/controllers/api/v1/sets_controller.rb
@@ -8,6 +8,14 @@ module Api
 
       before_action :validate_uuids, only: [:update_relationship, :create_relationship]
       before_action :create_uuids, only: [:update_relationship, :create_relationship]
+      before_action :check_lock, only: [:update, :destroy]
+
+      # This is the only way I found to prevent deleting materials from a set via 'patch'
+      def check_lock
+        if Aker::Set.find(params[:id]).locked?
+          return render json: { errors: [{ status: '422', title: 'Unprocessable entity', detail: 'Set locked' }]}, status: :unprocessable_entity
+        end
+      end
 
       # Fail request if the materials do not exist in materials service
       def validate_uuids
@@ -20,7 +28,25 @@ module Api
         param_uuids.each { |uuid| Aker::Material.find_or_create_by!(id: uuid) }
       end
 
-      private
+      def clone
+        cloneparams = clone_params
+        set = Aker::Set.find(cloneparams[:set_id])
+        copy = set.clone(cloneparams[:name])
+        unless copy.save
+          return render json: { errors: [{ status: '422', title: 'Unprocessable entity', detail: 'The clone could not be created'}]}, status: :unprocessable_entity
+        end
+        # Ideally, render the complete JSONAPI version of the copy, with links, but I can't find any way to do that
+        render json: copy, status: :created
+      end
+
+    private
+
+      def clone_params
+        {
+          set_id: params.require(:set_id),
+          name: params.require(:data).require(:attributes).require(:name),
+        }
+      end
 
       def param_uuids
         params.require(:data).pluck(:id)

--- a/app/models/aker/set.rb
+++ b/app/models/aker/set.rb
@@ -3,4 +3,16 @@ class Aker::Set < ApplicationRecord
   has_many :materials, through: :set_materials, source: :aker_material
 
   validates :name, presence: true, uniqueness: true
+
+  validate :validate_locked, if: :locked_was
+
+  def validate_locked
+    errors.add(:base, "Set is locked") unless changes.empty?
+  end
+
+  def clone(newname)
+    copy = Aker::Set.create(name: newname, locked: false)
+    copy.materials += materials
+    copy
+  end
 end

--- a/app/models/aker/set_material.rb
+++ b/app/models/aker/set_material.rb
@@ -1,4 +1,13 @@
 class Aker::SetMaterial < ApplicationRecord
   belongs_to :aker_set, class_name: "Aker::Set"
   belongs_to :aker_material, class_name: "Aker::Material"
+
+  validate :lock_validation
+
+  def lock_validation
+    return true unless aker_set.locked || aker_set.locked_was
+    errors.add(:base, "Set is locked")
+    false
+  end
+
 end

--- a/app/resources/api/v1/set_resource.rb
+++ b/app/resources/api/v1/set_resource.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class SetResource < JSONAPI::Resource
       model_name 'Aker::Set'
-      attributes :name, :created_at
+      attributes :name, :created_at, :locked
       has_many :materials, class_name: 'Material', relation_name: :materials, acts_as_set: true
 
       def meta(options)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       jsonapi_resources :sets do
         jsonapi_relationships
+        post 'clone', to: 'sets#clone'
       end
     end
   end

--- a/db/migrate/20170216100248_add_locked_boolean_to_aker_sets.rb
+++ b/db/migrate/20170216100248_add_locked_boolean_to_aker_sets.rb
@@ -1,0 +1,5 @@
+class AddLockedBooleanToAkerSets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :aker_sets, :locked, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214085150) do
+ActiveRecord::Schema.define(version: 20170216100248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,8 +32,9 @@ ActiveRecord::Schema.define(version: 20161214085150) do
 
   create_table "aker_sets", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "locked",     default: false, null: false
   end
 
   add_foreign_key "aker_set_materials", "aker_materials"

--- a/spec/models/aker/set_spec.rb
+++ b/spec/models/aker/set_spec.rb
@@ -11,4 +11,26 @@ RSpec.describe Aker::Set, type: :model do
     expect(build(:aker_set, name: set.name)).to_not be_valid
   end
 
+  it 'can be edited when unlocked' do
+    set = create(:aker_set, name: 'jeff')
+    expect(set.name).to eq 'jeff'
+    expect(set.update_attributes(name: 'dave')).to eq true
+    expect(set).to be_valid
+    expect(set.name).to eq 'dave'
+  end
+
+  it 'cannot be unlocked' do
+    set = create(:aker_set, locked: true)
+    expect(set).to be_valid
+    expect(set.update_attributes(name: 'dirk')).to eq false
+    expect(set).to_not be_valid
+  end
+
+  it 'cannot be edited after locking' do
+    set = create(:aker_set, name: 'jeff')
+    expect(set.update_attributes(locked: true)).to eq true
+    expect(set).to be_valid
+    expect(set.update_attributes(name: 'dirk')).to eq false
+    expect(set).to_not be_valid
+  end
 end


### PR DESCRIPTION
You can lock a set. Validation will prevent it being unlocked.
Validation will prevent any attributes of the locked set being updated.
Validation cannot prevent you deleting materials from a set.
A before_action in SetsController prevents issuing a patch to a locked set,
which is the way the set-shaping app updates the contents of a set.

You can post to sets/:id/clone to clone a set. The clone will have the
same contents, whatever name you specify, and will initially be unlocked.