### PR TITLE
Because of the change in the credentials, now all the operations are …

### DIFF
--- a/spec/integration/sets_spec.rb
+++ b/spec/integration/sets_spec.rb
@@ -11,7 +11,10 @@ describe 'Sets API' do
       consumes 'application/vnd.api+json'
       produces 'application/vnd.api+json'
 
+      parameter name: 'HTTP_X_AUTHORISATION', in: :header, type: :string
+      
       response '200', 'sets found' do
+        let(:HTTP_X_AUTHORISATION) { jwt }
         schema type: :object, properties: {
           data: {
             type: :array,
@@ -58,8 +61,10 @@ describe 'Sets API' do
           }
         }
       }
+      parameter name: 'HTTP_X_AUTHORISATION', in: :header, type: :string
 
       response '201', 'set created' do
+        let(:HTTP_X_AUTHORISATION) { jwt }
         let(:set) do
           set = build(:aker_set)
 

--- a/spec/requests/api/v1/sets_spec.rb
+++ b/spec/requests/api/v1/sets_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Api::V1::Sets', type: :request do
 
       before do
         aker_set = create_list(:aker_set, 3)
-
         get api_v1_sets_path, headers: headers
       end
 
@@ -116,7 +115,8 @@ RSpec.describe 'Api::V1::Sets', type: :request do
 
         get api_v1_set_path(aker_set), headers: {
           "Content-Type": "application/vnd.api+json",
-          "Accept": "application/vnd.api+json"
+          "Accept": "application/vnd.api+json",
+          "HTTP_X_AUTHORISATION" => jwt
         }
       end
 
@@ -259,7 +259,8 @@ RSpec.describe 'Api::V1::Sets', type: :request do
 
         get api_v1_set_materials_path(set_with_materials), headers: {
           "Content-Type": "application/vnd.api+json",
-          "Accept": "application/vnd.api+json"
+          "Accept": "application/vnd.api+json",
+          "HTTP_X_AUTHORISATION" => jwt
         }
       end
 
@@ -565,6 +566,7 @@ RSpec.describe 'Api::V1::Sets', type: :request do
           get api_v1_sets_path, params: { "filter[owner_id]" => jeff }, headers: {
             "Content-Type": "application/vnd.api+json",
             "Accept": "application/vnd.api+json",
+            "HTTP_X_AUTHORISATION" => jwt
           }
           @body = JSON.parse(response.body, symbolize_names: true)
           expect(@body[:data].length).to eq 2
@@ -578,6 +580,7 @@ RSpec.describe 'Api::V1::Sets', type: :request do
           get api_v1_sets_path, params: { "filter[owner_id]" => 'bananas' }, headers: {
             "Content-Type": "application/vnd.api+json",
             "Accept": "application/vnd.api+json",
+            "HTTP_X_AUTHORISATION" => jwt
           }
           @body = JSON.parse(response.body, symbolize_names: true)
           expect(@body[:data].length).to eq 0


### PR DESCRIPTION
…being

authenticated. The change in these tests is because the tests were not
checking the different status depending on the authentication, but the
action itself (create set, add elements, etc), therefore we
will suppose an authenticated user for all of them.
If we want to check the specific access to a particular functionality for an
unauthorized user, then a specific test should be made for these specific cases.