### PR TITLE
sanitise set names on creation

### DIFF
--- a/app/models/aker/set.rb
+++ b/app/models/aker/set.rb
@@ -7,8 +7,8 @@ class Aker::Set < ApplicationRecord
 
   validate :validate_locked, if: :locked_was
 
-  before_save :strip_name
-  before_validation :strip_name
+  before_save :sanitise_name
+  before_validation :sanitise_name
 
   def validate_locked
     errors.add(:base, "Set is locked") unless changes.empty?
@@ -24,10 +24,12 @@ class Aker::Set < ApplicationRecord
     (access.to_sym==:read || owner_id.nil? || (username.is_a?(String) ? owner_id==username : username.include?(owner_id) ))
   end
 
-  def strip_name
-    stripped = name&.strip
-    if stripped != name
-      self.name = stripped
+  def sanitise_name
+    if name
+      sanitised = name.strip.gsub(/\s+/,' ')
+      if sanitised != name
+        self.name = sanitised
+      end
     end
   end
 

--- a/spec/models/aker/set_spec.rb
+++ b/spec/models/aker/set_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Aker::Set, type: :model do
     expect(build(:aker_set, name: set.name)).to_not be_valid
   end
 
-  it 'is not valid with a different capitalisation of an exising name' do
+  it 'is not valid with a different capitalisation of an existing name' do
     set = create(:aker_set, name: 'jeff_set')
     expect(build(:aker_set, name: 'JEFF_SET')).not_to be_valid
   end
@@ -22,9 +22,14 @@ RSpec.describe Aker::Set, type: :model do
     expect(set.name).to eq('jeff')
   end
 
-  it 'is not valid without a unique stripped name' do
-    set = create(:aker_set, name: '  jeff')
-    expect(build(:aker_set, name: 'JEFF  ')).not_to be_valid
+  it 'has groups of whitespace contracted' do
+    set = create(:aker_set, name: " alpha\tbeta    gamma\n")
+    expect(set.name).to eq('alpha beta gamma')
+  end
+
+  it 'is not valid without a unique sanitised name' do
+    set = create(:aker_set, name: 'jeff alpha')
+    expect(build(:aker_set, name: 'JEFF   ALPHA ')).not_to be_valid
   end
 
   context 'when the set is unlocked' do


### PR DESCRIPTION
In particular, contract groups of whitespace (\s+) to a single space.